### PR TITLE
Upgrade dependencies

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -25,8 +25,8 @@ library
                       , containers   == 0.5.*
                       , mtl          == 2.2.*
                       , text         == 1.2.*
-                      , time         == 1.5.*
-                      , transformers == 0.4.*
+                      , time         >= 1.5 && < 1.7
+                      , transformers >= 0.4 && < 0.6
   default-language:     Haskell2010
 
 test-suite spec
@@ -42,8 +42,8 @@ test-suite spec
                       , quickcheck-instances == 0.3.*
                       , QuickCheck           == 2.8.*
                       , text                 == 1.2.*
-                      , time                 == 1.5.*
-                      , transformers         == 0.4.*
+                      , time                 >= 1.5 && < 1.7
+                      , transformers         >= 0.4 && < 0.6
     default-language:   Haskell2010
 
 

--- a/envy.cabal
+++ b/envy.cabal
@@ -34,16 +34,16 @@ test-suite spec
     ghc-options:        -Wall
     hs-source-dirs:     tests
     main-is:            Main.hs
-    build-depends:      base                 >= 4.7 && < 5
-                      , bytestring           == 0.10.*
+    build-depends:      base
+                      , bytestring
                       , envy                 == 1.1.*
                       , hspec                == 2.2.*
-                      , mtl                  == 2.2.*
+                      , mtl
                       , quickcheck-instances == 0.3.*
                       , QuickCheck           == 2.8.*
-                      , text                 == 1.2.*
-                      , time                 >= 1.5 && < 1.7
-                      , transformers         >= 0.4 && < 0.6
+                      , text
+                      , time
+                      , transformers
     default-language:   Haskell2010
 
 

--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -111,7 +111,7 @@ runEnv = runExceptT . runParser
 ------------------------------------------------------------------------------
 -- | Environment variable getter
 getE
-  :: forall a . (Typeable a, Var a)
+  :: forall a . (Var a)
   => String
   -> Parser a
 getE k = do
@@ -126,7 +126,7 @@ getE k = do
 
 ------------------------------------------------------------------------------
 -- | Environment variable getter
-env :: forall a. (Typeable a, Var a)
+env :: forall a. (Var a)
     => String
     -> Parser a
 env = getE
@@ -134,7 +134,7 @@ env = getE
 ------------------------------------------------------------------------------
 -- | Environment variable getter returning `Maybe`
 getEMaybe
-  :: forall a . (Typeable a, Var a)
+  :: forall a . (Var a)
   => String
   -> Parser (Maybe a)
 getEMaybe k = do
@@ -145,15 +145,14 @@ getEMaybe k = do
 
 ------------------------------------------------------------------------------
 -- | Environment variable getter returning `Maybe`
-envMaybe :: forall a. (Typeable a, Var a)
+envMaybe :: forall a. (Var a)
   => String
   -> Parser (Maybe a)
 envMaybe = getEMaybe
 
 ------------------------------------------------------------------------------
 -- | For use with (.:?) for providing default arguments
-(.!=) :: forall a. (Typeable a, Var a)
-  => Parser (Maybe a)
+(.!=) :: Parser (Maybe a)
   -> a
   -> Parser a
 (.!=) p x  = fmap (fromMaybe x) p
@@ -218,7 +217,7 @@ instance GFromEnv a => GFromEnv (D1 i a) where gFromEnv (M1 x) opts = M1 <$> gFr
 
 ------------------------------------------------------------------------------
 -- | Construct a `Parser` from a `selName` and `DefConfig` record field
-instance (Selector s, Typeable a, Var a) => GFromEnv (S1 s (K1 i a)) where
+instance (Selector s, Var a) => GFromEnv (S1 s (K1 i a)) where
   gFromEnv m@(M1 (K1 def)) opts =
       M1 . K1 <$> envMaybe (toEnvName opts $ selName m) .!= def
     where
@@ -253,7 +252,7 @@ data EnvList a = EnvList [EnvVar] deriving (Show)
 
 ------------------------------------------------------------------------------
 -- | smart constructor, Environment creation helper
-makeEnv :: ToEnv a => [EnvVar] -> EnvList a
+makeEnv :: [EnvVar] -> EnvList a
 makeEnv = EnvList
 
 ------------------------------------------------------------------------------
@@ -312,7 +311,7 @@ setEnvironment' = setEnvironment . toEnv
 
 ------------------------------------------------------------------------------
 -- | Unset Environment from a `ToEnv` constrained type
-unsetEnvironment :: ToEnv a => EnvList a -> IO (Either String ())
+unsetEnvironment :: EnvList a -> IO (Either String ())
 unsetEnvironment (EnvList xs) = do
   result <- try $ mapM_ (unsetEnv . fst . getEnvVar) xs
   return $ case result of


### PR DESCRIPTION
This adds support for `time` 1.6 and `transformers` 0.5, which is necessary to build with [the latest Stackage snapshot](https://www.stackage.org/nightly-2016-06-09). 

Only 6286e25 is really necessary. The rest is cleanup. 

Unrelated to this issue, it would be nice if Envy was available in Stackage. Have you considered [adding it](https://github.com/fpco/stackage/blob/a665b6251ef60c41799cf30c75ace6186e19f25d/README.md#add-your-package)? 