### PR TITLE
Export two things

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -1,5 +1,5 @@
 name:                envy
-version:             1.3.0.2
+version:             1.3.1.0
 synopsis:            An environmentally friendly way to deal with environment variables
 license:             BSD3
 license-file:        LICENSE

--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -49,6 +49,7 @@ module System.Envy
        , ToEnv   (..)
        , Var     (..)
        , EnvList
+       , Parser
         -- * Functions
        , decodeEnv
        , decode
@@ -67,6 +68,7 @@ module System.Envy
        , Option (..)
        , runEnv
        , gFromEnvCustom
+       , runParser
        ) where
 ------------------------------------------------------------------------------
 import           Control.Applicative


### PR DESCRIPTION
#Hi David,

To have no access to `Parser` and `runParser` is too restrictive and inconventient. E.g. this function I cannot write _with_ type description, since currently `Parser` is not accessible:
```
      -- envPair :: (Typeable a, Typeable b) => String -> String -> E.Parser (Maybe a, Maybe b)
      envPair key1 key2 = do
        val1 <- envMaybe key1
        val2 <- envMaybe key2
        if isNothing val1 && isNothing val2
          then throwError $ "Parameters either " <> key1 <> " or " <> key2 <> " should be set"
          else return (val1, val2)
```
I have to write to wrap it to a newtype and create `FromEnv` typeclass instance unnecessarily.

`runParser` is necessary to play with the loading in `ghci`.