### PR TITLE
Add Var (Maybe a) instance

### DIFF
--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -289,6 +289,10 @@ instance Var Word32 where toVar = show; fromVar = readMaybe
 instance Var Word64 where toVar = show; fromVar = readMaybe
 instance Var String where toVar = id; fromVar = Just
 instance Var () where toVar = const "()"; fromVar = const $ Just ()
+instance Var a => Var (Maybe a) where
+  toVar = maybe "" toVar
+  fromVar "" = Nothing
+  fromVar  s = Just <$> fromVar s
 
 ------------------------------------------------------------------------------
 -- | Environment retrieval with failure info


### PR DESCRIPTION
A common use case seems to be missing from the library: I'd like to represent "undefined"/empty variables as `Nothing` instead of having to check for `== ""`.