### PR TITLE
fixing blank strings

### DIFF
--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -78,7 +78,7 @@ import           Data.Char
 import           Data.Time
 import           GHC.Generics
 import           Data.Typeable
-import           System.Environment
+import           System.Environment.Blank
 import           Text.Read (readMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -123,7 +123,7 @@ env :: Var a
     => String   -- ^ Key to look up.
     -> Parser a -- ^ Return a value of this type or throw an error.
 env key = do
-  result <- liftIO (lookupEnv key)
+  result <- liftIO (getEnv key)
   case result of
     Nothing -> throwError $ "Variable not found for: " ++ key
     Just dv ->
@@ -139,7 +139,7 @@ envMaybe :: Var a
          => String           -- ^ Key to look up.
          -> Parser (Maybe a) -- ^ Return `Nothing` if variable isn't set.
 envMaybe key = do
-  val <- liftIO (lookupEnv key)
+  val <- liftIO (getEnv key)
   return $ case val of
    Nothing -> Nothing
    Just x -> fromVar x
@@ -317,7 +317,7 @@ wrapIOException action = try action >>= \case
 -- | Set environment via a ToEnv constrained type
 setEnvironment :: EnvList a -> IO (Either String ())
 setEnvironment (EnvList envVars) = wrapIOException $ mapM_ set envVars
-  where set var = setEnv (variableName var) (variableValue var)
+  where set var = setEnv (variableName var) (variableValue var) True
 
 ------------------------------------------------------------------------------
 -- | Set environment directly using a value of class ToEnv


### PR DESCRIPTION
The regular `System.Environment.setEnv` has a strange behaviour with empty strings

From [documentation](http://hackage.haskell.org/package/base-4.12.0.0/docs/System-Environment.html)

> Early versions of this function operated under the mistaken belief that setting an environment variable to the empty string on Windows removes that environment variable from the environment. For the sake of compatibility, it adopted that behavior on POSIX. 

`System.Environment.Blank.setEnv` solves this question

> Like setEnv, but allows blank environment values and mimics the function signature of setEnv from the unix package.
