### PR TITLE
Nodefault

### DIFF
--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -69,6 +69,7 @@ module System.Envy
          -- * Generics
        , DefConfig (..)
        , Option (..)
+       , defOption
        , runEnv
        , gFromEnvCustom
        ) where

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -96,6 +96,7 @@ instance ToEnv PGConfig where
                                , "PG_DB"   .= pgDB
                                ]
 
+
 ------------------------------------------------------------------------------
 -- | Start tests
 main :: IO ()
@@ -171,3 +172,5 @@ main = hspec $ do
                                   ]
                  decodeEnv
         assert $  if isInfixOf "\NUL" (userName u) then True else res == Right u
+
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -49,7 +49,7 @@ instance DefConfig ConnectInfo where
   defConfig = ConnectInfo "localhost" 5432 "user" "pass" "db"
 
 -- | Generic instance with default values
-instance FromEnvDefault ConnectInfo
+instance FromEnv ConnectInfo
 
 instance Arbitrary ConnectInfo where
     arbitrary = ConnectInfo <$> nonulls
@@ -78,11 +78,11 @@ instance Show PGConfig where
 -- | FromEnv Instances, supports popular aeson combinators *and* IO
 -- for dealing with connection pools
 instance FromEnv PGConfig where
-  fromEnv = PGConfig <$> (ConnectInfo <$> envMaybe "PG_HOST" .!= "localhost"
-                                      <*> env "PG_PORT"
-                                      <*> env "PG_USER"
-                                      <*> env "PG_PASS"
-                                      <*> env "PG_DB")
+  fromEnv _ = PGConfig <$> (ConnectInfo <$> envMaybe "PG_HOST" .!= "localhost"
+                                        <*> env "PG_PORT"
+                                        <*> env "PG_USER"
+                                        <*> env "PG_PASS"
+                                        <*> env "PG_DB")
 
 ------------------------------------------------------------------------------
 -- | To Environment Instances
@@ -158,8 +158,8 @@ main = hspec $ do
                                   , "PG_PASS" .= pgPass
                                   , "PG_DB"   .= pgDB
                                   ]
-                 decodeEnvDefault
-        assert $ res == Right ci
+                 decodeWithDefaults (defConfig :: ConnectInfo)
+        assert $ res == ci
   describe "Can use generic FromEnvNoDefault" $
     it "Isomorphism through setEnvironment and decodeEnv" $ property $
       \(u::UserInfo) -> monadicIO $ do


### PR DESCRIPTION
The main changes are reflected in the README change

This leaves `decode` and `decodeEnv` the client functions, with the same signature.

It adds an optional value to the `fromEnv` and `gFromEnvCustom`. 
As the extra argument is in last position of `gFromEnvCustom` and of `fromEnv`, the custom code for `fromEnv` using `gFromEnvCustom` previously written should work automatically.
Direct implementation for fromEnv have an extra argument, and need to be modified.

A new client function `decodeWithDefaults` is added.