### PR TITLE
Export GFromEnv typeclass

### DIFF
--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -49,6 +49,7 @@
 module System.Envy
        ( -- * Classes
          FromEnv (..)
+       , GFromEnv (..)
        , ToEnv   (..)
        , Var     (..)
        , EnvList (..)


### PR DESCRIPTION
This allows one to write a convenience function for ``FromEnv`` instances:
```haskell
envWithPrefix :: (Generic a, GFromEnv (Rep a)) => String -> (Maybe a -> Parser a)
envWithPrefix prefix = gFromEnvCustom Option {dropPrefixCount = 0, customPrefix = [prefix}

instance FromEnv Foo where
  fromEnv = envWithPrefix "FOO"
```