### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -21,7 +21,7 @@ library
   ghc-options:          -Wall
   hs-source-dirs:       src
   build-depends:        base         >= 4.11 && < 5
-                      , bytestring   == 0.10.*
+                      , bytestring   >= 0.10 && < 0.12
                       , containers   >= 0.5 && < 0.7
                       , mtl          == 2.2.*
                       , text         == 1.2.*


### PR DESCRIPTION
This allows using `envy` with base 4.16 (and GHC 9.2.4).