### PR TITLE
Allow bytestring-0.11.*, text-2.0.*

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -21,10 +21,10 @@ library
   ghc-options:          -Wall
   hs-source-dirs:       src
   build-depends:        base         >= 4.11 && < 5
-                      , bytestring   == 0.10.*
+                      , bytestring   == 0.10.* || == 0.11.*
                       , containers   >= 0.5 && < 0.7
                       , mtl          == 2.2.*
-                      , text         == 1.2.*
+                      , text         == 1.2.* || == 2.0.*
                       , time         >= 1.5 && < 2.0
                       , transformers >= 0.4 && < 0.6
   default-language:     Haskell2010


### PR DESCRIPTION
Tested using

    cabal test --enable-tests --constraint="text>=2.0" --constraint="bytestring>=0.11"
