### PR TITLE
Compatibility with ^>= mtl-2.3.1

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -23,10 +23,10 @@ library
   build-depends:        base         >= 4.11 && < 5
                       , bytestring   == 0.10.* || == 0.11.*
                       , containers   >= 0.5 && < 0.7
-                      , mtl          == 2.2.*
+                      , mtl          == 2.2.* || == 2.3.*
                       , text         == 1.2.* || == 2.0.*
                       , time         >= 1.5 && < 2.0
-                      , transformers >= 0.4 && < 0.6
+                      , transformers >= 0.4 && < 0.7
   default-language:     Haskell2010
 
 test-suite spec

--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -80,8 +80,9 @@ module System.Envy
        ) where
 ------------------------------------------------------------------------------
 import           Control.Applicative
-import           Control.Monad.Except
-import           Control.Monad.Fail
+import           Control.Monad (MonadPlus)
+import           Control.Monad.Except (ExceptT, MonadError, runExceptT, throwError)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Exception
 import           Data.Functor.Identity
 import           Data.Maybe


### PR DESCRIPTION
I made the Except imports explicit since otherwise you'd get warnings on
mtl-2.2 making you think the new imports are redundant, which they aren't with
mtl-2.3.
