### PR TITLE
README: Fix non-compiling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ defConfig :: PGConfig
 defConfig = PGConfig "localhost" 5432
 
 main :: IO ()
-main =
+main = do
   _ <- setEnv "PG_HOST" "customURL" True
-  print =<< decodeWithDefaults defConfig :: IO (Either String PGConfig)
+  print =<< decodeWithDefaults defConfig
  -- > PGConfig { pgHost = "customURL", pgPort = 5432 }
 ```
 


### PR DESCRIPTION
Hello,

Thank you for this library.
I noticed an example in the README that wouldn't compile because `decodeWithDefaults` does not return `Either String a`. Most probably it was an incorrect copy paste error from `decodeEnv` example.
Hope you don't mind me sending a patch to fix that. :)