### PR TITLE
Relax bounds for text and bytestring

### DIFF
--- a/envy.cabal
+++ b/envy.cabal
@@ -21,10 +21,10 @@ library
   ghc-options:          -Wall
   hs-source-dirs:       src
   build-depends:        base         >= 4.11 && < 5
-                      , bytestring   == 0.10.* || == 0.11.*
+                      , bytestring   >= 0.10 && < 0.13
                       , containers   >= 0.5 && < 0.7
                       , mtl          == 2.2.* || == 2.3.*
-                      , text         == 1.2.* || == 2.0.*
+                      , text         == 1.2.* || >= 2.0 && <2.2
                       , time         >= 1.5 && < 2.0
                       , transformers >= 0.4 && < 0.7
   default-language:     Haskell2010

--- a/src/System/Envy.hs
+++ b/src/System/Envy.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeOperators              #-}


### PR DESCRIPTION
Hello,
Is it possible we can relax bounds for bytestring (v0.12 is out on hackage) and text (v2.1.* is out).
Tested with `cabal test --enable-tests --constraint="bytestring>=0.12" --constraint="text>=2.1"`.